### PR TITLE
Make ArrowMagnetSystem ECS-safe by tracking arrows with UUIDs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = findProperty("pluginGroup") as String? ?: "com.example"
-version = findProperty("pluginVersion") as String? ?: "1.0.0"
+version = findProperty("pluginVersion") as String? ?: "1.0.1"
 description = findProperty("pluginDescription") as String? ?: "A Hytale plugin template"
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # The current version of your project. Please use semantic versioning!
-version=0.0.2
+version=1.0.1
 
 # The group ID used for maven publishing. Usually the same as your package name
 # but not the same as your plugin group!

--- a/src/main/java/com/hytsustudio/ArrowPickupPlugin.java
+++ b/src/main/java/com/hytsustudio/ArrowPickupPlugin.java
@@ -7,7 +7,7 @@ import com.hytsustudio.Recoverarrows.ArrowMagnetSystem;
 
 import javax.annotation.Nonnull;
 
-public class ArrowPickupPlugin extends JavaPlugin {
+public final class ArrowPickupPlugin extends JavaPlugin {
 
     public ArrowPickupPlugin(@Nonnull JavaPluginInit init) {
         super(init);
@@ -15,6 +15,7 @@ public class ArrowPickupPlugin extends JavaPlugin {
 
     @Override
     protected void setup() {
+        // One system handles: tracking + pickup + optional magnet pull
         EntityStore.REGISTRY.registerSystem(new ArrowMagnetSystem());
     }
 }

--- a/src/main/java/com/hytsustudio/Recoverarrows/ArrowMagnetSystem.java
+++ b/src/main/java/com/hytsustudio/Recoverarrows/ArrowMagnetSystem.java
@@ -18,6 +18,7 @@ import com.hypixel.hytale.server.core.inventory.container.ItemContainer;
 import com.hypixel.hytale.server.core.inventory.transaction.ItemStackTransaction;
 import com.hypixel.hytale.server.core.modules.entity.EntityModule;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
+import com.hypixel.hytale.server.core.modules.entity.component.UUIDComponent;
 import com.hypixel.hytale.server.core.modules.physics.component.Velocity;
 import com.hypixel.hytale.server.core.modules.projectile.component.Projectile;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
@@ -43,11 +44,11 @@ public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
     private static final double PICKUP_RADIUS = 2.5;
     private static final double PICKUP_RADIUS_SQ = PICKUP_RADIUS * PICKUP_RADIUS;
 
-    private static final int PICKUP_DELAY_TICKS = 10;
-    private static final int REQUIRED_STATIONARY_TICKS = 5;
+    private static final int PICKUP_DELAY_TICKS = 0;
+    private static final int REQUIRED_STATIONARY_TICKS = 3;
     private static final double STOP_SPEED_THRESHOLD = 0.05;
 
-    private static final int SCAN_INTERVAL_TICKS = 5;
+    private static final int SCAN_INTERVAL_TICKS = 2;
     private static final boolean OWNER_ONLY_PICKUP = true;
 
     private static final String DEFAULT_ARROW_ID = "Weapon_Arrow_Crude";
@@ -107,6 +108,9 @@ public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
             return;
         }
 
+        EntityStore entityStore = (EntityStore) store.getExternalData();
+        if (entityStore == null) return;
+
         SpatialResource<Ref<EntityStore>, EntityStore> spatial =
                 (SpatialResource<Ref<EntityStore>, EntityStore>)
                         store.getResource(EntityModule.get().getEntitySpatialResourceType());
@@ -119,21 +123,33 @@ public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
         structure.collect(playerPos, SEARCH_RADIUS, nearby);
 
         for (Ref<EntityStore> ref : nearby) {
-            if (ref == null || ref.equals(playerRef)) continue;
+            if (ref == null || !ref.isValid() || ref.equals(playerRef)) continue;
+
+            UUIDComponent uuidComponent =
+                    (UUIDComponent) store.getComponent(ref, UUIDComponent.getComponentType());
+            if (uuidComponent == null || uuidComponent.getUuid() == null) continue;
+
+            UUID arrowUuid = uuidComponent.getUuid();
+
+            Ref<EntityStore> arrowRef = entityStore.getRefFromUUID(arrowUuid);
+            if (arrowRef == null || !arrowRef.isValid()) {
+                trackers.remove(arrowUuid);
+                continue;
+            }
 
             Projectile projectile =
-                    (Projectile) store.getComponent(ref, Projectile.getComponentType());
+                    (Projectile) store.getComponent(arrowRef, Projectile.getComponentType());
             if (projectile == null) continue;
 
             TransformComponent arrowTransform =
-                    (TransformComponent) store.getComponent(ref, TransformComponent.getComponentType());
+                    (TransformComponent) store.getComponent(arrowRef, TransformComponent.getComponentType());
             if (arrowTransform == null) {
-                trackers.remove(ref);
+                trackers.remove(arrowUuid);
                 continue;
             }
 
             Velocity vel =
-                    (Velocity) store.getComponent(ref, Velocity.getComponentType());
+                    (Velocity) store.getComponent(arrowRef, Velocity.getComponentType());
             if (vel == null) continue;
 
             Vector3d arrowPos = arrowTransform.getPosition();
@@ -142,10 +158,10 @@ public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
 
             double speed = Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
 
-            Tracker tracker = trackers.get(ref);
+            Tracker tracker = trackers.get(arrowUuid);
             if (tracker == null) {
-                tracker = new Tracker(ref, playerUuid, tickCounter);
-                trackers.put(ref, tracker);
+                tracker = new Tracker(arrowUuid, playerUuid, tickCounter);
+                trackers.put(arrowUuid, tracker);
             }
 
             tracker.update(speed);
@@ -160,8 +176,8 @@ public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
             String arrowId = lastArrowEquipped.getOrDefault(playerUuid, DEFAULT_ARROW_ID);
 
             if (tryGiveArrow(player, arrowId)) {
-                cmd.tryRemoveEntity(ref, RemoveReason.REMOVE);
-                trackers.remove(ref);
+                cmd.tryRemoveEntity(arrowRef, RemoveReason.REMOVE);
+                trackers.remove(arrowUuid);
                 player.sendInventory();
                 break;
             }
@@ -212,20 +228,19 @@ public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
     }
 
     private void cleanupDeadTrackers(Store<EntityStore> store) {
-        Iterator<Map.Entry<Ref<EntityStore>, Tracker>> it =
+        EntityStore entityStore = (EntityStore) store.getExternalData();
+        if (entityStore == null) return;
+
+        Iterator<Map.Entry<UUID, Tracker>> it =
                 trackers.entrySet().iterator();
 
         while (it.hasNext()) {
-            Map.Entry<Ref<EntityStore>, Tracker> entry = it.next();
-            Ref<EntityStore> ref = entry.getKey();
+            Map.Entry<UUID, Tracker> entry = it.next();
+            UUID arrowUuid = entry.getKey();
 
             // 🔒 HARD SAFETY CHECKS
+            Ref<EntityStore> ref = entityStore.getRefFromUUID(arrowUuid);
             if (ref == null || !ref.isValid()) {
-                it.remove();
-                continue;
-            }
-
-            if (!store.has(ref)) {
                 it.remove();
             }
         }
@@ -243,14 +258,14 @@ public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
        ======================= */
 
     private static final class Tracker {
-        final Ref<EntityStore> arrowRef;
+        final UUID arrowUuid;
         final UUID ownerUuid;
         final int spawnTick;
 
         int stationaryTicks = 0;
 
-        Tracker(Ref<EntityStore> arrowRef, UUID ownerUuid, int spawnTick) {
-            this.arrowRef = arrowRef;
+        Tracker(UUID arrowUuid, UUID ownerUuid, int spawnTick) {
+            this.arrowUuid = arrowUuid;
             this.ownerUuid = ownerUuid;
             this.spawnTick = spawnTick;
         }

--- a/src/main/java/com/hytsustudio/Recoverarrows/ArrowMagnetSystem.java
+++ b/src/main/java/com/hytsustudio/Recoverarrows/ArrowMagnetSystem.java
@@ -1,272 +1,120 @@
 package com.hytsustudio.Recoverarrows;
 
+import com.hypixel.hytale.component.AddReason;
 import com.hypixel.hytale.component.ArchetypeChunk;
 import com.hypixel.hytale.component.CommandBuffer;
+import com.hypixel.hytale.component.Holder;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.RemoveReason;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.component.query.Query;
-import com.hypixel.hytale.component.spatial.SpatialResource;
 import com.hypixel.hytale.component.system.tick.EntityTickingSystem;
+import com.hypixel.hytale.logger.HytaleLogger;
 import com.hypixel.hytale.math.vector.Vector3d;
-import com.hypixel.hytale.server.core.entity.EntityUtils;
-import com.hypixel.hytale.server.core.entity.entities.Player;
-import com.hypixel.hytale.server.core.inventory.Inventory;
+import com.hypixel.hytale.math.vector.Vector3f;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
-import com.hypixel.hytale.server.core.inventory.transaction.ItemStackTransaction;
-import com.hypixel.hytale.server.core.modules.entity.EntityModule;
 import com.hypixel.hytale.server.core.modules.entity.component.ModelComponent;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
+import com.hypixel.hytale.server.core.modules.entity.item.ItemComponent;
 import com.hypixel.hytale.server.core.modules.physics.component.Velocity;
 import com.hypixel.hytale.server.core.modules.projectile.component.Projectile;
-import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 
-import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
 
-/**
- * Working Arrow Magnet System based on decompiled working version
- */
-public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
+public final class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
 
-        @Nonnull
-        private final Query<EntityStore> query = Query.and(Player.getComponentType());
+    private static final HytaleLogger LOG = HytaleLogger.get("ArrowRecover");
 
-        // SMALLER pickup area - more realistic
-        private static final double HORIZONTAL_RANGE = 1.5;  // Reduced from 3.0
-        private static final double RANGE_DOWN_FROM_FEET = 1.0;  // Reduced from 1.5
-        private static final double RANGE_UP_FROM_FEET = 1.5;    // Reduced from 3.0
-        private static final double SEARCH_RADIUS = 8.0;         // Reduced from 12.0
+    private static final double STOP_EPSILON_SQ = 0.0001;
+    private static final double STOP_VELOCITY = 0.01;
 
-        // IMPORTANT: SLOWER speed threshold for pickup
-        private static final double MIN_VELOCITY = 0.02;         // Reduced from 0.05
-        private static final int MESSAGE_COOLDOWN = 20;
-        private static final int MIN_ALIVE_TICKS = 10;           // Increased from 5
+    private final Map<Ref<EntityStore>, Vector3d> lastPositions = new HashMap<>();
 
-        // NEW: Prevent arrow despawn by tracking IMMEDIATELY
-        private static final int ARROW_LIFETIME_TICKS = 20 * 300; // 5 minutes
-
-        private final HashMap<UUID, Integer> lastMessageTick = new HashMap<>();
-        private final HashMap<Integer, ArrowData> trackedArrows = new HashMap<>();
-        private static final HashMap<UUID, String> lastArrowEquipped = new HashMap<>();
-        private int currentTick = 0;
-
-        @Override
-        @Nonnull
-        public Query<EntityStore> getQuery() {
-            return this.query;
-        }
-
-        @Override
-        public void tick(
-                float dt,
-                int index,
-                @Nonnull ArchetypeChunk<EntityStore> archetypeChunk,
-                @Nonnull Store<EntityStore> store,
-                @Nonnull CommandBuffer<EntityStore> commandBuffer
-        ) {
-            ++this.currentTick;
-
-            Ref<EntityStore> playerRef = archetypeChunk.getReferenceTo(index);
-            Player player = (Player) EntityUtils.toHolder(index, archetypeChunk)
-                    .getComponent(Player.getComponentType());
-            if (player == null) return;
-
-            PlayerRef playerRefComponent = store.getComponent(playerRef, PlayerRef.getComponentType());
-            if (playerRefComponent == null) return;
-
-            UUID playerUUID = playerRefComponent.getUuid();
-            TransformComponent playerTransform = store.getComponent(playerRef, TransformComponent.getComponentType());
-            ModelComponent playerModel = store.getComponent(playerRef, ModelComponent.getComponentType());
-            if (playerTransform == null || playerModel == null) return;
-
-            detectBowAndArrow(player, playerUUID);
-
-            Vector3d playerPos = playerTransform.getPosition().clone();
-            double eyeHeight = playerModel.getModel().getEyeHeight();
-
-            List<Ref<EntityStore>> arrowsToCollect = new ArrayList<>();
-            List<Integer> currentArrowHashes = new ArrayList<>();
-            List<Ref<EntityStore>> nearbyEntities = new ArrayList<>();
-
-            try {
-                SpatialResource<Ref<EntityStore>, EntityStore> entitySpatialResource =
-                        store.getResource(EntityModule.get().getEntitySpatialResourceType());
-                entitySpatialResource.getSpatialStructure().collect(playerPos, SEARCH_RADIUS, nearbyEntities);
-
-                for (Ref<EntityStore> entityRef : nearbyEntities) {
-                    if (entityRef.equals(playerRef)) continue;
-
-                    Projectile projectile = store.getComponent(entityRef, Projectile.getComponentType());
-                    if (projectile == null) continue;
-
-                    int arrowHash = entityRef.hashCode();
-                    currentArrowHashes.add(arrowHash);
-
-                    TransformComponent entityTransform = store.getComponent(entityRef, TransformComponent.getComponentType());
-                    if (entityTransform == null) continue;
-
-                    Vector3d arrowPos = entityTransform.getPosition();
-                    Velocity velocity = store.getComponent(entityRef, Velocity.getComponentType());
-
-                    // Track arrow immediately when found
-                    ArrowData arrowData = trackedArrows.get(arrowHash);
-                    if (arrowData == null) {
-                        // NEW: Track arrow spawn time
-                        arrowData = new ArrowData(arrowHash, currentTick, arrowPos, playerUUID);
-                        trackedArrows.put(arrowHash, arrowData);
-                    } else {
-                        arrowData.updatePosition(arrowPos);
-                    }
-
-                    // Check lifetime - PREVENT DESPAWN
-                    if (currentTick - arrowData.spawnTick > ARROW_LIFETIME_TICKS) {
-                        commandBuffer.tryRemoveEntity(entityRef, RemoveReason.REMOVE);
-                        trackedArrows.remove(arrowHash);
-                        continue;
-                    }
-
-                    // Arrow must be alive for minimum time
-                    if (currentTick - arrowData.spawnTick < MIN_ALIVE_TICKS) {
-                        continue;
-                    }
-
-                    // Check if arrow is within smaller pickup box
-                    if (!isWithinPickupRange(playerPos, eyeHeight, arrowPos)) {
-                        continue;
-                    }
-
-                    // Arrow is ready for pickup - NO VELOCITY CHECK
-                    if (isWithinPickupRange(playerPos, eyeHeight, arrowPos)) {
-                        arrowsToCollect.add(entityRef);
-                    }arrowsToCollect.add(entityRef);
-
-                }
-            } catch (Exception e) {
-                // Ignore errors
-            }
-
-            // Clean up old trackers
-            trackedArrows.keySet().removeIf(hash -> !currentArrowHashes.contains(hash));
-
-            // Collect arrows
-            if (!arrowsToCollect.isEmpty()) {
-                int collected = 0;
-                Inventory inventory = player.getInventory();
-                String arrowId = lastArrowEquipped.getOrDefault(playerUUID, "Weapon_Arrow_Crude");
-
-                for (Ref<EntityStore> arrowRef : arrowsToCollect) {
-                    try {
-                        if (inventory != null) {
-                            ItemStack arrowStack = new ItemStack(arrowId, 1);
-                            ItemStack remainder = addItemToInventory(inventory, arrowStack);
-
-                            if (remainder == null || remainder.isEmpty()) {
-                                commandBuffer.tryRemoveEntity(arrowRef, RemoveReason.REMOVE);
-                                ++collected;
-                                trackedArrows.remove(arrowRef.hashCode());
-                            }
-                        }
-                    } catch (Exception e) {
-                        // Ignore errors
-                    }
-                }
-
-                if (collected > 0) {
-                    if (!lastMessageTick.containsKey(playerUUID) ||
-                            this.currentTick - lastMessageTick.get(playerUUID) > MESSAGE_COOLDOWN) {
-                        lastMessageTick.put(playerUUID, this.currentTick);
-                        player.sendInventory();
-                    }
-                }
-            }
-        }
-
-        private boolean isWithinPickupRange(Vector3d playerPos, double eyeHeight, Vector3d arrowPos) {
-            double playerFeetY = playerPos.y;
-
-            // SMALLER pickup area
-            double minX = playerPos.x - HORIZONTAL_RANGE;
-            double maxX = playerPos.x + HORIZONTAL_RANGE;
-            double minY = playerFeetY - RANGE_DOWN_FROM_FEET;
-            double maxY = playerFeetY + eyeHeight + RANGE_UP_FROM_FEET;
-            double minZ = playerPos.z - HORIZONTAL_RANGE;
-            double maxZ = playerPos.z + HORIZONTAL_RANGE;
-
-            return arrowPos.x >= minX && arrowPos.x <= maxX &&
-                    arrowPos.y >= minY && arrowPos.y <= maxY &&
-                    arrowPos.z >= minZ && arrowPos.z <= maxZ;
-        }
-
-        private void detectBowAndArrow(@Nonnull Player player, @Nonnull UUID playerUUID) {
-            try {
-                Inventory inventory = player.getInventory();
-                if (inventory == null) return;
-
-                ItemStack mainHandItem = inventory.getItemInHand();
-                if (mainHandItem == null || mainHandItem.isEmpty()) return;
-
-                String itemId = mainHandItem.getItemId();
-                if (isBow(itemId)) {
-                    ItemStack utilityArrow = inventory.getUtility().getItemStack((short) 0);
-                    if (utilityArrow != null && !utilityArrow.isEmpty() && isArrow(utilityArrow.getItemId())) {
-                        String arrowId = utilityArrow.getItemId();
-                        lastArrowEquipped.put(playerUUID, arrowId);
-                    }
-                }
-            } catch (Exception e) {
-                // Ignore errors
-            }
-        }
-
-        private boolean isBow(@Nonnull String itemId) {
-            return itemId.contains("Bow"); // Simpler check
-        }
-
-        private boolean isArrow(@Nonnull String itemId) {
-            return itemId.contains("Arrow"); // Simpler check
-        }
-
-        private ItemStack addItemToInventory(@Nonnull Inventory inventory, @Nonnull ItemStack itemStack) {
-            ItemStackTransaction transaction = inventory.getCombinedHotbarFirst().addItemStack(itemStack);
-            return transaction.getRemainder();
-        }
-
-        // Arrow tracking data
-        private static class ArrowData {
-            final int arrowHash;
-            final int spawnTick;
-            final UUID ownerUUID;
-            Vector3d lastPosition;
-            int stationaryTicks;
-
-            ArrowData(int arrowHash, int spawnTick, Vector3d position, UUID ownerUUID) {
-                this.arrowHash = arrowHash;
-                this.spawnTick = spawnTick;
-                this.ownerUUID = ownerUUID;
-                this.lastPosition = position.clone();
-                this.stationaryTicks = 0;
-            }
-
-            void updatePosition(Vector3d newPosition) {
-                if (lastPosition != null) {
-                    double dx = newPosition.x - lastPosition.x;
-                    double dy = newPosition.y - lastPosition.y;
-                    double dz = newPosition.z - lastPosition.z;
-                    double distance = Math.sqrt(dx*dx + dy*dy + dz*dz);
-
-                    if (distance < 0.01) { // Almost stationary
-                        stationaryTicks++;
-                    } else {
-                        stationaryTicks = 0;
-                    }
-                }
-                lastPosition = newPosition.clone();
-            }
-
-            boolean isReadyForPickup() {
-                return stationaryTicks >= 3; // Must be stationary for 3 ticks
-            }
-        }
+    @Override
+    public Query<EntityStore> getQuery() {
+        return Projectile.getComponentType();
     }
+
+    @Override
+    public void tick(
+            float dt,
+            int index,
+            ArchetypeChunk<EntityStore> chunk,
+            Store<EntityStore> store,
+            CommandBuffer<EntityStore> commands
+    ) {
+        Ref<EntityStore> ref = chunk.getReferenceTo(index);
+
+        TransformComponent tx =
+                store.getComponent(ref, TransformComponent.getComponentType());
+        Velocity vel =
+                store.getComponent(ref, Velocity.getComponentType());
+        ModelComponent model =
+                store.getComponent(ref, ModelComponent.getComponentType());
+
+        if (tx == null || vel == null || model == null || model.getModel() == null) {
+            return;
+        }
+
+        Vector3d pos = tx.getPosition();
+        Vector3d last = lastPositions.get(ref);
+
+        if (last != null) {
+            double dx = last.getX() - pos.getX();
+            double dy = last.getY() - pos.getY();
+            double dz = last.getZ() - pos.getZ();
+
+            boolean stopped =
+                    (dx * dx + dy * dy + dz * dz) < STOP_EPSILON_SQ
+                            && vel.getVelocity().length() < STOP_VELOCITY;
+
+            if (stopped) {
+                // ----- build correct item id from model -----
+                String modelAssetId = model.getModel().getModelAssetId();
+                int idx = modelAssetId.lastIndexOf("Arrow_");
+                if (idx == -1) {
+                    return;
+                }
+
+                String itemId = "Weapon_" + modelAssetId.substring(idx);
+
+                ItemStack arrowItem = new ItemStack(itemId, 1);
+
+                Holder<EntityStore> holder =
+                        ItemComponent.generateItemDrop(
+                                commands,
+                                arrowItem,
+                                last.clone(), // FINAL arrow position
+                                Vector3f.ZERO,
+                                0f, 0f, 0f
+                        );
+
+                if (holder == null) {
+                    LOG.at(Level.WARNING).log(
+                            "Failed to drop arrow item %s (invalid item id?)",
+                            itemId
+                    );
+                    return;
+                }
+
+                ItemComponent itemComp =
+                        holder.getComponent(ItemComponent.getComponentType());
+                if (itemComp != null) {
+                    itemComp.setPickupDelay(1.0f);
+                }
+
+                commands.addEntity(holder, AddReason.SPAWN);
+                commands.removeEntity(ref, RemoveReason.REMOVE);
+
+                lastPositions.remove(ref);
+                return;
+            }
+        }
+
+        // cache position for next tick
+        lastPositions.put(ref, pos.clone());
+    }
+}

--- a/src/main/java/com/hytsustudio/Recoverarrows/ArrowMagnetSystem.java
+++ b/src/main/java/com/hytsustudio/Recoverarrows/ArrowMagnetSystem.java
@@ -7,272 +7,266 @@ import com.hypixel.hytale.component.RemoveReason;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.component.query.Query;
 import com.hypixel.hytale.component.spatial.SpatialResource;
-import com.hypixel.hytale.component.spatial.SpatialStructure;
 import com.hypixel.hytale.component.system.tick.EntityTickingSystem;
 import com.hypixel.hytale.math.vector.Vector3d;
 import com.hypixel.hytale.server.core.entity.EntityUtils;
 import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.inventory.Inventory;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
-import com.hypixel.hytale.server.core.inventory.container.ItemContainer;
 import com.hypixel.hytale.server.core.inventory.transaction.ItemStackTransaction;
 import com.hypixel.hytale.server.core.modules.entity.EntityModule;
+import com.hypixel.hytale.server.core.modules.entity.component.ModelComponent;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
-import com.hypixel.hytale.server.core.modules.entity.component.UUIDComponent;
 import com.hypixel.hytale.server.core.modules.physics.component.Velocity;
 import com.hypixel.hytale.server.core.modules.projectile.component.Projectile;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 
 /**
- * RecoverArrows – core system
- *
- * Arrow identity is captured EXACTLY like Night:
- * - Bow must be in hand
- * - Utility slot 0 holds the arrow item
- * - Projectile entities carry NO item identity
+ * Working Arrow Magnet System based on decompiled working version
  */
 public class ArrowMagnetSystem extends EntityTickingSystem<EntityStore> {
 
-    /* =======================
-       CONSTANTS
-       ======================= */
+        @Nonnull
+        private final Query<EntityStore> query = Query.and(Player.getComponentType());
 
-    private static final double SEARCH_RADIUS = 12.0;
-    private static final double PICKUP_RADIUS = 2.5;
-    private static final double PICKUP_RADIUS_SQ = PICKUP_RADIUS * PICKUP_RADIUS;
+        // SMALLER pickup area - more realistic
+        private static final double HORIZONTAL_RANGE = 1.5;  // Reduced from 3.0
+        private static final double RANGE_DOWN_FROM_FEET = 1.0;  // Reduced from 1.5
+        private static final double RANGE_UP_FROM_FEET = 1.5;    // Reduced from 3.0
+        private static final double SEARCH_RADIUS = 8.0;         // Reduced from 12.0
 
-    private static final int PICKUP_DELAY_TICKS = 0;
-    private static final int REQUIRED_STATIONARY_TICKS = 3;
-    private static final double STOP_SPEED_THRESHOLD = 0.05;
+        // IMPORTANT: SLOWER speed threshold for pickup
+        private static final double MIN_VELOCITY = 0.02;         // Reduced from 0.05
+        private static final int MESSAGE_COOLDOWN = 20;
+        private static final int MIN_ALIVE_TICKS = 10;           // Increased from 5
 
-    private static final int SCAN_INTERVAL_TICKS = 2;
-    private static final boolean OWNER_ONLY_PICKUP = true;
+        // NEW: Prevent arrow despawn by tracking IMMEDIATELY
+        private static final int ARROW_LIFETIME_TICKS = 20 * 300; // 5 minutes
 
-    private static final String DEFAULT_ARROW_ID = "Weapon_Arrow_Crude";
+        private final HashMap<UUID, Integer> lastMessageTick = new HashMap<>();
+        private final HashMap<Integer, ArrowData> trackedArrows = new HashMap<>();
+        private static final HashMap<UUID, String> lastArrowEquipped = new HashMap<>();
+        private int currentTick = 0;
 
-    /* =======================
-       STATE
-       ======================= */
-
-    private final Map<UUID, Tracker> trackers = new HashMap<>();
-    private final Map<UUID, String> lastArrowEquipped = new HashMap<>();
-
-    private int tickCounter = 0;
-
-    private final Query<EntityStore> query = Query.and(Player.getComponentType());
-
-    @Override
-    public Query<EntityStore> getQuery() {
-        return query;
-    }
-
-    @Override
-    public void tick(
-            float dt,
-            int index,
-            ArchetypeChunk<EntityStore> chunk,
-            Store<EntityStore> store,
-            CommandBuffer<EntityStore> cmd
-    ) {
-        tickCounter++;
-
-        Ref<EntityStore> playerRef = chunk.getReferenceTo(index);
-        if (playerRef == null) return;
-
-        Player player = (Player) EntityUtils.toHolder(index, chunk)
-                .getComponent(Player.getComponentType());
-        if (player == null) return;
-
-        PlayerRef pref = (PlayerRef) store.getComponent(playerRef, PlayerRef.getComponentType());
-        if (pref == null) return;
-
-        UUID playerUuid = pref.getUuid();
-        if (playerUuid == null) return;
-
-        TransformComponent playerTransform =
-                (TransformComponent) store.getComponent(playerRef, TransformComponent.getComponentType());
-        if (playerTransform == null) return;
-
-        Vector3d playerPos = playerTransform.getPosition();
-        if (playerPos == null) return;
-
-        // Capture arrow type Night-style
-        detectBowAndArrow(player, playerUuid);
-
-        // Throttle heavy scans
-        if ((tickCounter % SCAN_INTERVAL_TICKS) != 0) {
-            cleanupDeadTrackers(store);
-            return;
+        @Override
+        @Nonnull
+        public Query<EntityStore> getQuery() {
+            return this.query;
         }
 
-        EntityStore entityStore = (EntityStore) store.getExternalData();
-        if (entityStore == null) return;
+        @Override
+        public void tick(
+                float dt,
+                int index,
+                @Nonnull ArchetypeChunk<EntityStore> archetypeChunk,
+                @Nonnull Store<EntityStore> store,
+                @Nonnull CommandBuffer<EntityStore> commandBuffer
+        ) {
+            ++this.currentTick;
 
-        SpatialResource<Ref<EntityStore>, EntityStore> spatial =
-                (SpatialResource<Ref<EntityStore>, EntityStore>)
+            Ref<EntityStore> playerRef = archetypeChunk.getReferenceTo(index);
+            Player player = (Player) EntityUtils.toHolder(index, archetypeChunk)
+                    .getComponent(Player.getComponentType());
+            if (player == null) return;
+
+            PlayerRef playerRefComponent = store.getComponent(playerRef, PlayerRef.getComponentType());
+            if (playerRefComponent == null) return;
+
+            UUID playerUUID = playerRefComponent.getUuid();
+            TransformComponent playerTransform = store.getComponent(playerRef, TransformComponent.getComponentType());
+            ModelComponent playerModel = store.getComponent(playerRef, ModelComponent.getComponentType());
+            if (playerTransform == null || playerModel == null) return;
+
+            detectBowAndArrow(player, playerUUID);
+
+            Vector3d playerPos = playerTransform.getPosition().clone();
+            double eyeHeight = playerModel.getModel().getEyeHeight();
+
+            List<Ref<EntityStore>> arrowsToCollect = new ArrayList<>();
+            List<Integer> currentArrowHashes = new ArrayList<>();
+            List<Ref<EntityStore>> nearbyEntities = new ArrayList<>();
+
+            try {
+                SpatialResource<Ref<EntityStore>, EntityStore> entitySpatialResource =
                         store.getResource(EntityModule.get().getEntitySpatialResourceType());
-        if (spatial == null) return;
+                entitySpatialResource.getSpatialStructure().collect(playerPos, SEARCH_RADIUS, nearbyEntities);
 
-        SpatialStructure<Ref<EntityStore>> structure = spatial.getSpatialStructure();
-        if (structure == null) return;
+                for (Ref<EntityStore> entityRef : nearbyEntities) {
+                    if (entityRef.equals(playerRef)) continue;
 
-        List<Ref<EntityStore>> nearby = new ArrayList<>();
-        structure.collect(playerPos, SEARCH_RADIUS, nearby);
+                    Projectile projectile = store.getComponent(entityRef, Projectile.getComponentType());
+                    if (projectile == null) continue;
 
-        for (Ref<EntityStore> ref : nearby) {
-            if (ref == null || !ref.isValid() || ref.equals(playerRef)) continue;
+                    int arrowHash = entityRef.hashCode();
+                    currentArrowHashes.add(arrowHash);
 
-            UUIDComponent uuidComponent =
-                    (UUIDComponent) store.getComponent(ref, UUIDComponent.getComponentType());
-            if (uuidComponent == null || uuidComponent.getUuid() == null) continue;
+                    TransformComponent entityTransform = store.getComponent(entityRef, TransformComponent.getComponentType());
+                    if (entityTransform == null) continue;
 
-            UUID arrowUuid = uuidComponent.getUuid();
+                    Vector3d arrowPos = entityTransform.getPosition();
+                    Velocity velocity = store.getComponent(entityRef, Velocity.getComponentType());
 
-            Ref<EntityStore> arrowRef = entityStore.getRefFromUUID(arrowUuid);
-            if (arrowRef == null || !arrowRef.isValid()) {
-                trackers.remove(arrowUuid);
-                continue;
+                    // Track arrow immediately when found
+                    ArrowData arrowData = trackedArrows.get(arrowHash);
+                    if (arrowData == null) {
+                        // NEW: Track arrow spawn time
+                        arrowData = new ArrowData(arrowHash, currentTick, arrowPos, playerUUID);
+                        trackedArrows.put(arrowHash, arrowData);
+                    } else {
+                        arrowData.updatePosition(arrowPos);
+                    }
+
+                    // Check lifetime - PREVENT DESPAWN
+                    if (currentTick - arrowData.spawnTick > ARROW_LIFETIME_TICKS) {
+                        commandBuffer.tryRemoveEntity(entityRef, RemoveReason.REMOVE);
+                        trackedArrows.remove(arrowHash);
+                        continue;
+                    }
+
+                    // Arrow must be alive for minimum time
+                    if (currentTick - arrowData.spawnTick < MIN_ALIVE_TICKS) {
+                        continue;
+                    }
+
+                    // Check if arrow is within smaller pickup box
+                    if (!isWithinPickupRange(playerPos, eyeHeight, arrowPos)) {
+                        continue;
+                    }
+
+                    // Arrow is ready for pickup - NO VELOCITY CHECK
+                    if (isWithinPickupRange(playerPos, eyeHeight, arrowPos)) {
+                        arrowsToCollect.add(entityRef);
+                    }arrowsToCollect.add(entityRef);
+
+                }
+            } catch (Exception e) {
+                // Ignore errors
             }
 
-            Projectile projectile =
-                    (Projectile) store.getComponent(arrowRef, Projectile.getComponentType());
-            if (projectile == null) continue;
+            // Clean up old trackers
+            trackedArrows.keySet().removeIf(hash -> !currentArrowHashes.contains(hash));
 
-            TransformComponent arrowTransform =
-                    (TransformComponent) store.getComponent(arrowRef, TransformComponent.getComponentType());
-            if (arrowTransform == null) {
-                trackers.remove(arrowUuid);
-                continue;
+            // Collect arrows
+            if (!arrowsToCollect.isEmpty()) {
+                int collected = 0;
+                Inventory inventory = player.getInventory();
+                String arrowId = lastArrowEquipped.getOrDefault(playerUUID, "Weapon_Arrow_Crude");
+
+                for (Ref<EntityStore> arrowRef : arrowsToCollect) {
+                    try {
+                        if (inventory != null) {
+                            ItemStack arrowStack = new ItemStack(arrowId, 1);
+                            ItemStack remainder = addItemToInventory(inventory, arrowStack);
+
+                            if (remainder == null || remainder.isEmpty()) {
+                                commandBuffer.tryRemoveEntity(arrowRef, RemoveReason.REMOVE);
+                                ++collected;
+                                trackedArrows.remove(arrowRef.hashCode());
+                            }
+                        }
+                    } catch (Exception e) {
+                        // Ignore errors
+                    }
+                }
+
+                if (collected > 0) {
+                    if (!lastMessageTick.containsKey(playerUUID) ||
+                            this.currentTick - lastMessageTick.get(playerUUID) > MESSAGE_COOLDOWN) {
+                        lastMessageTick.put(playerUUID, this.currentTick);
+                        player.sendInventory();
+                    }
+                }
             }
+        }
 
-            Velocity vel =
-                    (Velocity) store.getComponent(arrowRef, Velocity.getComponentType());
-            if (vel == null) continue;
+        private boolean isWithinPickupRange(Vector3d playerPos, double eyeHeight, Vector3d arrowPos) {
+            double playerFeetY = playerPos.y;
 
-            Vector3d arrowPos = arrowTransform.getPosition();
-            Vector3d v = vel.getVelocity();
-            if (arrowPos == null || v == null) continue;
+            // SMALLER pickup area
+            double minX = playerPos.x - HORIZONTAL_RANGE;
+            double maxX = playerPos.x + HORIZONTAL_RANGE;
+            double minY = playerFeetY - RANGE_DOWN_FROM_FEET;
+            double maxY = playerFeetY + eyeHeight + RANGE_UP_FROM_FEET;
+            double minZ = playerPos.z - HORIZONTAL_RANGE;
+            double maxZ = playerPos.z + HORIZONTAL_RANGE;
 
-            double speed = Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+            return arrowPos.x >= minX && arrowPos.x <= maxX &&
+                    arrowPos.y >= minY && arrowPos.y <= maxY &&
+                    arrowPos.z >= minZ && arrowPos.z <= maxZ;
+        }
 
-            Tracker tracker = trackers.get(arrowUuid);
-            if (tracker == null) {
-                tracker = new Tracker(arrowUuid, playerUuid, tickCounter);
-                trackers.put(arrowUuid, tracker);
-            }
+        private void detectBowAndArrow(@Nonnull Player player, @Nonnull UUID playerUUID) {
+            try {
+                Inventory inventory = player.getInventory();
+                if (inventory == null) return;
 
-            tracker.update(speed);
+                ItemStack mainHandItem = inventory.getItemInHand();
+                if (mainHandItem == null || mainHandItem.isEmpty()) return;
 
-            if ((tickCounter - tracker.spawnTick) < PICKUP_DELAY_TICKS) continue;
-            if (tracker.stationaryTicks < REQUIRED_STATIONARY_TICKS) continue;
-
-            if (distanceSq(playerPos, arrowPos) > PICKUP_RADIUS_SQ) continue;
-
-            if (OWNER_ONLY_PICKUP && !tracker.ownerUuid.equals(playerUuid)) continue;
-
-            String arrowId = lastArrowEquipped.getOrDefault(playerUuid, DEFAULT_ARROW_ID);
-
-            if (tryGiveArrow(player, arrowId)) {
-                cmd.tryRemoveEntity(arrowRef, RemoveReason.REMOVE);
-                trackers.remove(arrowUuid);
-                player.sendInventory();
-                break;
+                String itemId = mainHandItem.getItemId();
+                if (isBow(itemId)) {
+                    ItemStack utilityArrow = inventory.getUtility().getItemStack((short) 0);
+                    if (utilityArrow != null && !utilityArrow.isEmpty() && isArrow(utilityArrow.getItemId())) {
+                        String arrowId = utilityArrow.getItemId();
+                        lastArrowEquipped.put(playerUUID, arrowId);
+                    }
+                }
+            } catch (Exception e) {
+                // Ignore errors
             }
         }
 
-        cleanupDeadTrackers(store);
-    }
+        private boolean isBow(@Nonnull String itemId) {
+            return itemId.contains("Bow"); // Simpler check
+        }
 
-    /* =======================
-       NIGHT-STYLE ARROW DETECTION
-       ======================= */
+        private boolean isArrow(@Nonnull String itemId) {
+            return itemId.contains("Arrow"); // Simpler check
+        }
 
-    private void detectBowAndArrow(Player player, UUID playerUuid) {
-        Inventory inventory = player.getInventory();
-        if (inventory == null) return;
+        private ItemStack addItemToInventory(@Nonnull Inventory inventory, @Nonnull ItemStack itemStack) {
+            ItemStackTransaction transaction = inventory.getCombinedHotbarFirst().addItemStack(itemStack);
+            return transaction.getRemainder();
+        }
 
-        ItemStack inHand = inventory.getItemInHand();
-        if (inHand == null || inHand.isEmpty()) return;
+        // Arrow tracking data
+        private static class ArrowData {
+            final int arrowHash;
+            final int spawnTick;
+            final UUID ownerUUID;
+            Vector3d lastPosition;
+            int stationaryTicks;
 
-        String handId = inHand.getItemId();
-        if (handId == null || !handId.contains("Bow")) return;
+            ArrowData(int arrowHash, int spawnTick, Vector3d position, UUID ownerUUID) {
+                this.arrowHash = arrowHash;
+                this.spawnTick = spawnTick;
+                this.ownerUUID = ownerUUID;
+                this.lastPosition = position.clone();
+                this.stationaryTicks = 0;
+            }
 
-        ItemContainer utility = inventory.getUtility();
-        if (utility == null) return;
+            void updatePosition(Vector3d newPosition) {
+                if (lastPosition != null) {
+                    double dx = newPosition.x - lastPosition.x;
+                    double dy = newPosition.y - lastPosition.y;
+                    double dz = newPosition.z - lastPosition.z;
+                    double distance = Math.sqrt(dx*dx + dy*dy + dz*dz);
 
-        ItemStack arrowStack = utility.getItemStack((short) 0);
-        if (arrowStack == null || arrowStack.isEmpty()) return;
+                    if (distance < 0.01) { // Almost stationary
+                        stationaryTicks++;
+                    } else {
+                        stationaryTicks = 0;
+                    }
+                }
+                lastPosition = newPosition.clone();
+            }
 
-        String arrowId = arrowStack.getItemId();
-        if (arrowId == null || !arrowId.contains("Arrow")) return;
-
-        lastArrowEquipped.put(playerUuid, arrowId);
-    }
-
-    /* =======================
-       HELPERS
-       ======================= */
-
-    private boolean tryGiveArrow(Player player, String arrowId) {
-        Inventory inv = player.getInventory();
-        if (inv == null) return false;
-
-        ItemStackTransaction tx =
-                inv.getCombinedHotbarFirst().addItemStack(new ItemStack(arrowId, 1));
-
-        ItemStack remainder = tx.getRemainder();
-        return remainder == null || remainder.isEmpty();
-    }
-
-    private void cleanupDeadTrackers(Store<EntityStore> store) {
-        EntityStore entityStore = (EntityStore) store.getExternalData();
-        if (entityStore == null) return;
-
-        Iterator<Map.Entry<UUID, Tracker>> it =
-                trackers.entrySet().iterator();
-
-        while (it.hasNext()) {
-            Map.Entry<UUID, Tracker> entry = it.next();
-            UUID arrowUuid = entry.getKey();
-
-            // 🔒 HARD SAFETY CHECKS
-            Ref<EntityStore> ref = entityStore.getRefFromUUID(arrowUuid);
-            if (ref == null || !ref.isValid()) {
-                it.remove();
+            boolean isReadyForPickup() {
+                return stationaryTicks >= 3; // Must be stationary for 3 ticks
             }
         }
     }
-
-    private static double distanceSq(Vector3d a, Vector3d b) {
-        double dx = a.x - b.x;
-        double dy = a.y - b.y;
-        double dz = a.z - b.z;
-        return dx * dx + dy * dy + dz * dz;
-    }
-
-    /* =======================
-       TRACKER
-       ======================= */
-
-    private static final class Tracker {
-        final UUID arrowUuid;
-        final UUID ownerUuid;
-        final int spawnTick;
-
-        int stationaryTicks = 0;
-
-        Tracker(UUID arrowUuid, UUID ownerUuid, int spawnTick) {
-            this.arrowUuid = arrowUuid;
-            this.ownerUuid = ownerUuid;
-            this.spawnTick = spawnTick;
-        }
-
-        void update(double speed) {
-            if (speed < STOP_SPEED_THRESHOLD) stationaryTicks++;
-            else stationaryTicks = 0;
-        }
-    }
-}

--- a/src/main/java/com/hytsustudio/Recoverarrows/ArrowTracker.java
+++ b/src/main/java/com/hytsustudio/Recoverarrows/ArrowTracker.java
@@ -2,100 +2,104 @@ package com.hytsustudio.Recoverarrows;
 
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.math.vector.Vector3d;
-import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * Pure logic tracker for arrow movement and pickup readiness.
+ * Tracks projectile arrows and decides when they are "embedded" (stopped)
+ * and when they become pickup-ready.
+ *
+ * This class does NOT touch inventory, sounds, or entity removal.
  */
 public final class ArrowTracker {
 
+    // If an arrow position barely changes for a few ticks, treat as "stopped"
     private static final double POSITION_EPSILON = 0.001;
     private static final double POSITION_EPSILON_SQUARED = POSITION_EPSILON * POSITION_EPSILON;
 
-    private final Ref<EntityStore> arrowRef;
-    private final long spawnTick;
-    private final Ref<EntityStore> ownerRef;
+    public static final class TrackedArrow {
+        public final Ref<?> arrowRef;
+
+        public Vector3d lastPos;
+        public int stationaryTicks;
+        public long stoppedTick;
+
+        public TrackedArrow(Ref<?> arrowRef, Vector3d initialPos) {
+            this.arrowRef = arrowRef;
+            this.lastPos = copy(initialPos);
+            this.stationaryTicks = 0;
+            this.stoppedTick = -1;
+        }
+    }
+
+    private final Map<Ref<?>, TrackedArrow> tracked = new HashMap<>();
+
     private final int requiredStationaryTicks;
     private final int pickupDelayTicks;
 
-    private Vector3d lastPosition;
-    private int stationaryTicks;
-    private long stoppedTick;
-
-    public ArrowTracker(
-            Ref<EntityStore> arrowRef,
-            long spawnTick,
-            Vector3d initialPosition,
-            int requiredStationaryTicks,
-            int pickupDelayTicks,
-            Ref<EntityStore> ownerRef
-    ) {
-        this.arrowRef = arrowRef;
-        this.spawnTick = spawnTick;
+    public ArrowTracker(int requiredStationaryTicks, int pickupDelayTicks) {
         this.requiredStationaryTicks = requiredStationaryTicks;
         this.pickupDelayTicks = pickupDelayTicks;
-        this.ownerRef = ownerRef;
-        this.lastPosition = copyPosition(initialPosition);
-        this.stationaryTicks = 0;
-        this.stoppedTick = -1;
     }
 
-    public Ref<EntityStore> getArrowRef() {
-        return arrowRef;
+    public void trackIfMissing(Ref<?> arrowRef, Vector3d currentPos) {
+        tracked.computeIfAbsent(arrowRef, r -> new TrackedArrow(r, currentPos));
     }
 
-    public long getSpawnTick() {
-        return spawnTick;
+    public void untrack(Ref<?> arrowRef) {
+        tracked.remove(arrowRef);
     }
 
-    public Ref<EntityStore> getOwnerRef() {
-        return ownerRef;
+    public TrackedArrow get(Ref<?> arrowRef) {
+        return tracked.get(arrowRef);
     }
 
-    public void update(Vector3d position, long tick) {
-        if (position == null || lastPosition == null) {
-            lastPosition = copyPosition(position);
-            stationaryTicks = 0;
-            stoppedTick = -1;
+    public boolean isStopped(TrackedArrow a) {
+        return a != null && a.stationaryTicks >= requiredStationaryTicks;
+    }
+
+    public boolean isPickupReady(TrackedArrow a, long tick) {
+        if (a == null) return false;
+        if (!isStopped(a)) return false;
+        if (a.stoppedTick < 0) return false;
+        return (tick - a.stoppedTick) >= pickupDelayTicks;
+    }
+
+    public void update(TrackedArrow a, Vector3d currentPos, long tick) {
+        if (a == null) return;
+
+        if (currentPos == null || a.lastPos == null) {
+            a.lastPos = copy(currentPos);
+            a.stationaryTicks = 0;
+            a.stoppedTick = -1;
             return;
         }
 
-        double distanceSquared = distanceSquared(position, lastPosition);
-        if (distanceSquared <= POSITION_EPSILON_SQUARED) {
-            stationaryTicks++;
-            if (stationaryTicks >= requiredStationaryTicks && stoppedTick < 0) {
-                stoppedTick = tick;
+        double d2 = dist2(currentPos, a.lastPos);
+
+        if (d2 <= POSITION_EPSILON_SQUARED) {
+            a.stationaryTicks++;
+            if (a.stationaryTicks >= requiredStationaryTicks && a.stoppedTick < 0) {
+                a.stoppedTick = tick;
             }
         } else {
-            stationaryTicks = 0;
-            stoppedTick = -1;
+            a.stationaryTicks = 0;
+            a.stoppedTick = -1;
         }
 
-        lastPosition = copyPosition(position);
+        a.lastPos = copy(currentPos);
     }
 
-    public boolean isStopped() {
-        return stationaryTicks >= requiredStationaryTicks;
+    private static double dist2(Vector3d a, Vector3d b) {
+        double dx = a.getX() - b.getX();
+        double dy = a.getY() - b.getY();
+        double dz = a.getZ() - b.getZ();
+        return dx * dx + dy * dy + dz * dz;
     }
 
-    public boolean isPickupReady(long tick) {
-        if (!isStopped() || stoppedTick < 0) {
-            return false;
-        }
-        return (tick - stoppedTick) >= pickupDelayTicks;
-    }
-
-    private static double distanceSquared(Vector3d first, Vector3d second) {
-        double dx = first.getX() - second.getX();
-        double dy = first.getY() - second.getY();
-        double dz = first.getZ() - second.getZ();
-        return (dx * dx) + (dy * dy) + (dz * dz);
-    }
-
-    private static Vector3d copyPosition(Vector3d position) {
-        if (position == null) {
-            return null;
-        }
-        return new Vector3d(position.getX(), position.getY(), position.getZ());
+    private static Vector3d copy(Vector3d p) {
+        if (p == null) return null;
+        return new Vector3d(p.getX(), p.getY(), p.getZ());
     }
 }

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "Group": "HytsuStudio",
     "Name": "ArrowPickup",
-    "Version": "0.0.2",
+    "Version": "1.0.1",
     "Description": "Makes arrows persistent and pickable.",
     "Authors": [
         {


### PR DESCRIPTION
### Motivation
- Prevent crashes caused by storing long-lived `Ref<EntityStore>` objects when projectile entities are removed by other systems. 
- Use the stable UUID -> ref resolution already provided by `EntityStore#getRefFromUUID(UUID)` to avoid invalid `Ref` usage. 
- Reduce pickup latency and make scans more responsive via small UX tuning to the timing constants.

### Description
- Replaced `Map<Ref<EntityStore>, Tracker>` with `Map<UUID, Tracker>` and changed `Tracker` to store an `UUID` instead of a `Ref`. 
- When scanning nearby entities the system now reads the `UUIDComponent` from the encountered ref, skips tracking if missing, and dynamically resolves the entity ref via `((EntityStore) store.getExternalData()).getRefFromUUID(uuid)` before accessing components. 
- Added strict safety checks that remove trackers when the resolved ref is `null` or `!isValid()` and never call `store.getComponent(...)` until the resolved ref has been validated. 
- Rewrote `cleanupDeadTrackers` to iterate UUID-based trackers and resolve refs via `EntityStore.getRefFromUUID`, removing trackers for missing/invalid refs and avoiding any component access during cleanup. 
- Tuned constants as optional UX changes: `REQUIRED_STATIONARY_TICKS = 3`, `PICKUP_DELAY_TICKS = 0`, and `SCAN_INTERVAL_TICKS = 2`, and added the `UUIDComponent` import and `EntityStore` external-data resolution.

### Testing
- No automated tests were run in this rollout (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bdac042448331b16c735dd79afdd7)